### PR TITLE
Add Binary tab to registers window

### DIFF
--- a/GUI/src/Windows/Core/RegistersWindow.cpp
+++ b/GUI/src/Windows/Core/RegistersWindow.cpp
@@ -2,6 +2,8 @@
 
 #include "Backend/GUI_backend.h"
 
+#include <bitset>
+
 //Basic Registers Window with buffers, using ImGui tables.
 
 RegistersWindow* RegistersWindow::Instance;
@@ -445,6 +447,140 @@ void RegistersWindow::Render()
 
 			ImGui::TableSetColumnIndex(3);
 			ImGui::Text("%04X", SP);
+
+			ImGui::EndTable();
+		}
+	}
+	ImGui::End();
+
+	ImGui::Begin("Binary");
+	{
+		if (ImGui::BeginTable("RegistersBin", 7, ImGuiTableFlags_Borders))
+		{
+			ImGui::TableNextRow();
+
+			ImGui::TableSetColumnIndex(0);
+			ImGui::Text("A");
+
+			ImGui::TableSetColumnIndex(1);
+			ImGui::Text("B");
+
+			ImGui::TableSetColumnIndex(2);
+			ImGui::Text("C");
+
+			ImGui::TableSetColumnIndex(3);
+			ImGui::Text("D");
+
+			ImGui::TableSetColumnIndex(4);
+			ImGui::Text("E");
+
+			ImGui::TableSetColumnIndex(5);
+			ImGui::Text("H");
+
+			ImGui::TableSetColumnIndex(6);
+			ImGui::Text("L");
+
+
+			ImGui::TableNextRow();
+
+			ImGui::TableSetColumnIndex(0);
+			ImGui::Text("%s", std::bitset<8>(A).to_string().c_str());
+
+			ImGui::TableSetColumnIndex(1);
+			ImGui::Text("%s", std::bitset<8>(B).to_string().c_str());
+
+			ImGui::TableSetColumnIndex(2);
+			ImGui::Text("%s", std::bitset<8>(C).to_string().c_str());
+
+			ImGui::TableSetColumnIndex(3);
+			ImGui::Text("%s", std::bitset<8>(D).to_string().c_str());
+
+			ImGui::TableSetColumnIndex(4);
+			ImGui::Text("%s", std::bitset<8>(E).to_string().c_str());
+
+			ImGui::TableSetColumnIndex(5);
+			ImGui::Text("%s", std::bitset<8>(H).to_string().c_str());
+
+			ImGui::TableSetColumnIndex(6);
+			ImGui::Text("%s", std::bitset<8>(L).to_string().c_str());
+
+			ImGui::EndTable();
+		}
+
+		if (ImGui::BeginTable("Flags-PC-SPBin", 6, ImGuiTableFlags_Borders))
+		{
+			ImGui::TableNextRow();
+
+			ImGui::TableSetColumnIndex(0);
+			ImGui::Text("M");
+
+			ImGui::TableSetColumnIndex(1);
+			ImGui::Text("S");
+
+			ImGui::TableSetColumnIndex(2);
+			ImGui::Text("Z");
+
+			ImGui::TableSetColumnIndex(3);
+			ImGui::Text("P");
+
+			ImGui::TableSetColumnIndex(4);
+			ImGui::Text("Cy");
+
+			ImGui::TableSetColumnIndex(5);
+			ImGui::Text("PC");
+
+			ImGui::TableNextRow();
+
+			ImGui::TableSetColumnIndex(0);
+			ImGui::Text("%s", std::bitset<8>(M).to_string().c_str());
+
+			ImGui::TableSetColumnIndex(1);
+			ImGui::Text("%d", Sign_flag);
+
+			ImGui::TableSetColumnIndex(2);
+			ImGui::Text("%d", Zero_flag);
+
+			ImGui::TableSetColumnIndex(3);
+			ImGui::Text("%d", Parity_flag);
+
+			ImGui::TableSetColumnIndex(4);
+			ImGui::Text("%d", Carry_flag);
+
+			ImGui::TableSetColumnIndex(5);
+			ImGui::Text("%s", std::bitset<16>(PC).to_string().c_str());
+
+			ImGui::EndTable();
+		}
+
+		if (ImGui::BeginTable("RPBin", 4, ImGuiTableFlags_Borders))
+		{
+			ImGui::TableNextRow();
+
+			ImGui::TableSetColumnIndex(0);
+			ImGui::Text("BC");
+
+			ImGui::TableSetColumnIndex(1);
+			ImGui::Text("DE");
+
+			ImGui::TableSetColumnIndex(2);
+			ImGui::Text("HL");
+
+			ImGui::TableSetColumnIndex(3);
+			ImGui::Text("SP");
+
+			ImGui::TableNextRow();
+
+			ImGui::TableSetColumnIndex(0);
+			ImGui::Text("%s", std::bitset<16>((B << 8) | (C)).to_string().c_str());
+
+			ImGui::TableSetColumnIndex(1);
+			ImGui::Text("%s", std::bitset<16>((D << 8) | (E)).to_string().c_str());
+
+			ImGui::TableSetColumnIndex(2);
+			ImGui::Text("%s", std::bitset<16>((H << 8) | (L)).to_string().c_str());
+
+			ImGui::TableSetColumnIndex(3);
+			ImGui::Text("%s", std::bitset<16>(SP).to_string().c_str());
 
 			ImGui::EndTable();
 		}


### PR DESCRIPTION
Added a binary tab to the registers window.
This can make it easier to work with instructions such as `RLC`, `RRC`, etc.
If this PR will be accepted, the [Wiki](https://github.com/FanisDeligiannis/8085_emulator/wiki) may also need to be edited [here](https://github.com/FanisDeligiannis/8085_emulator/wiki/Using-the-GUI.#register-panel) to include this change.
If there are any changes that need to be made to the code or PR, I'd be happy to make them.